### PR TITLE
feat: announce new game email to all players

### DIFF
--- a/frontend/src/lib/game-utils.ts
+++ b/frontend/src/lib/game-utils.ts
@@ -271,6 +271,15 @@ export async function adminTriggerWeeklyReset(): Promise<{ sent: number; failed:
   return apiClient.post('/weekly-reset', {});
 }
 
+export async function adminAnnounceGame(params: {
+  prize: string
+  game_type: string
+  theme: string
+  extra_message?: string
+}): Promise<{ sent: number; failed: number }> {
+  return apiClient.post('/game/admin/announce-game', params);
+}
+
 export async function unmarkCell(cardId: number, cellIndex: number): Promise<MarkCellResult> {
   return apiClient.post<MarkCellResult>('/game/unmark-cell', {
     card_id: cardId,

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -25,6 +25,7 @@ import {
   adminGetCellMarkLog,
   adminVoidCell,
   adminTriggerWeeklyReset,
+  adminAnnounceGame,
   adminGetTeams,
   adminCreateTeam,
   adminUpdateTeam,
@@ -99,6 +100,13 @@ const AdminPanel: React.FC = () => {
 
   // Weekly reset state
   const [weeklyResetLoading, setWeeklyResetLoading] = useState(false);
+
+  // Game announcement state
+  const [announceLoading, setAnnounceLoading] = useState(false);
+  const [announcePrize, setAnnouncePrize] = useState('');
+  const [announceGameType, setAnnounceGameType] = useState('');
+  const [announceTheme, setAnnounceTheme] = useState('');
+  const [announceExtra, setAnnounceExtra] = useState('');
 
   // Teams state
   const [teams, setTeams] = useState<TeamItem[]>([]);
@@ -306,6 +314,31 @@ const AdminPanel: React.FC = () => {
       toast.error(err?.message || 'Failed to send weekly emails.');
     } finally {
       setWeeklyResetLoading(false);
+    }
+  };
+
+  const handleAnnounceGame = async () => {
+    if (!announcePrize.trim() || !announceGameType.trim()) {
+      toast.error('Prize and Game Type are required.');
+      return;
+    }
+    setAnnounceLoading(true);
+    try {
+      const res = await adminAnnounceGame({
+        prize: announcePrize.trim(),
+        game_type: announceGameType.trim(),
+        theme: announceTheme.trim(),
+        extra_message: announceExtra.trim() || undefined,
+      });
+      toast.success(`Game announcement sent: ${res.sent} delivered, ${res.failed} failed.`);
+      setAnnouncePrize('');
+      setAnnounceGameType('');
+      setAnnounceTheme('');
+      setAnnounceExtra('');
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to send game announcement.');
+    } finally {
+      setAnnounceLoading(false);
     }
   };
 
@@ -1104,6 +1137,68 @@ const AdminPanel: React.FC = () => {
               className="bg-sky-600 hover:bg-sky-700 text-white font-bold"
             >
               {weeklyResetLoading ? 'Sending…' : 'Send Now to All Players'}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Game Announcement */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Mail className="w-5 h-5 text-emerald-500" />
+              Announce New Game to All Players
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-slate-500">
+              Send an email to all verified players announcing a new game. Include the prize, game type, and optional theme. A button overview is automatically included at the bottom of every announcement.
+            </p>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Prize <span className="text-red-500">*</span></label>
+              <input
+                type="text"
+                placeholder="e.g. $50 Amazon Gift Card"
+                value={announcePrize}
+                onChange={(e) => setAnnouncePrize(e.target.value)}
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Game Type <span className="text-red-500">*</span></label>
+              <input
+                type="text"
+                placeholder="e.g. One Line, Four Corners, Full Card"
+                value={announceGameType}
+                onChange={(e) => setAnnounceGameType(e.target.value)}
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Theme <span className="text-slate-400 text-xs">(optional)</span></label>
+              <input
+                type="text"
+                placeholder="e.g. Summer of Kindness"
+                value={announceTheme}
+                onChange={(e) => setAnnounceTheme(e.target.value)}
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700">Additional Message <span className="text-slate-400 text-xs">(optional)</span></label>
+              <textarea
+                placeholder="Any extra note to include in the email..."
+                value={announceExtra}
+                onChange={(e) => setAnnounceExtra(e.target.value)}
+                rows={3}
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 resize-none"
+              />
+            </div>
+            <Button
+              onClick={handleAnnounceGame}
+              disabled={announceLoading}
+              className="bg-emerald-600 hover:bg-emerald-700 text-white font-bold"
+            >
+              {announceLoading ? 'Sending…' : 'Send Announcement to All Players'}
             </Button>
           </CardContent>
         </Card>

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -72,6 +72,56 @@ function layout(innerHtml: string): string {
 
 // ── Templates ────────────────────────────────────────────────────────────────
 
+export function gameAnnouncementEmail(opts: {
+  name: string | null
+  prize: string
+  gameType: string
+  theme: string
+  extraMessage?: string
+}): { subject: string; html: string } {
+  const hi = opts.name && opts.name.trim() ? opts.name.trim() : 'there'
+  const themeLine = opts.theme ? `<p><strong>🎨 Theme:</strong> ${opts.theme}</p>` : ''
+  const extraLine = opts.extraMessage ? `<p style="margin-top:12px">${opts.extraMessage}</p>` : ''
+  return {
+    subject: `🎯 A new Havagr8day Bingo game has started!`,
+    html: layout(`
+      <h2 style="margin:0 0 12px;color:#4F46E5;font-size:20px">A new game has started, ${hi}!</h2>
+      <p>Here's what you need to know about this week's game:</p>
+      <div style="background:#f8fafc;border-radius:10px;padding:16px 20px;margin:16px 0;border-left:4px solid #4FB3E8">
+        <p style="margin:0 0 8px"><strong>🏆 Prize:</strong> ${opts.prize}</p>
+        <p style="margin:0 0 8px"><strong>🎮 Game Type:</strong> ${opts.gameType}</p>
+        ${themeLine}
+      </div>
+      ${extraLine}
+      <p style="text-align:center;margin:24px 0">
+        <a href="${SITE_URL}/game" style="display:inline-block;background:#DC2626;color:#fff;font-weight:bold;padding:13px 30px;border-radius:10px;text-decoration:none;border:2px solid #FCD34D">Play Now</a>
+      </p>
+      <div style="margin-top:24px;border-top:1px solid #e2e8f0;padding-top:16px">
+        <p style="margin:0 0 10px;font-weight:bold;color:#1e293b">Quick Guide to Game Panel Buttons:</p>
+        <table style="width:100%;border-collapse:collapse;font-size:14px">
+          <tr style="background:#f1f5f9">
+            <td style="padding:8px 10px;border-radius:6px 0 0 6px;font-weight:bold;color:#4F46E5">Pick Three</td>
+            <td style="padding:8px 10px;border-radius:0 6px 6px 0;color:#475569">Spend a little to mark up to 3 squares instantly — no deed required.</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px;font-weight:bold;color:#DC2626">💣 Bomb Button<br/><span style="font-size:12px;color:#94a3b8">(Hidden Square)</span></td>
+            <td style="padding:8px 10px;color:#475569">A surprise hidden square — could be good or bad. Tap to reveal!</td>
+          </tr>
+          <tr style="background:#f1f5f9">
+            <td style="padding:8px 10px;font-weight:bold;color:#7C3AED">I Dare Ya<br/><span style="font-size:12px;color:#94a3b8">(Centre Square)</span></td>
+            <td style="padding:8px 10px;color:#475569">Spin the centre square for a random challenge or reward.</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px;font-weight:bold;color:#059669">👛 Watch Your Wallet<br/><span style="font-size:12px;color:#94a3b8">(Hidden Square)</span></td>
+            <td style="padding:8px 10px;color:#475569">Another hidden square that adds or takes away a few dollars from your wallet.</td>
+          </tr>
+        </table>
+      </div>
+      <p style="color:#64748b;font-size:13px;margin-top:20px">Have a gr8 day — and make someone else's gr8 too.</p>
+    `),
+  }
+}
+
 export function verifyEmailEmail(verifyUrl: string): { subject: string; html: string } {
   return {
     subject: 'Verify your Havagr8day Bingo email address',

--- a/supabase/functions/game/index.ts
+++ b/supabase/functions/game/index.ts
@@ -1,7 +1,7 @@
 import { handleCors, jsonResponse, errorResponse } from '../_shared/cors.ts'
 import { getAuthUser, requireAuth, requireAdmin } from '../_shared/auth.ts'
 import { getSupabase, getSubPath, matchPath } from '../_shared/db.ts'
-import { sendEmail, passwordResetEmail, referralInviteEmail, bingoWinEmail, prizeClaimConfirmationEmail } from '../_shared/email.ts'
+import { sendEmail, passwordResetEmail, referralInviteEmail, bingoWinEmail, prizeClaimConfirmationEmail, gameAnnouncementEmail } from '../_shared/email.ts'
 import bcrypt from 'npm:bcryptjs@2'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -1172,6 +1172,44 @@ Deno.serve(async (req: Request) => {
       }).eq('id', card_id)
 
       return jsonResponse({ success: true, completed_cells: updatedCompleted, is_bingo: isBingo })
+    }
+
+    // ── POST /admin/announce-game ─────────────────────────────────────────────
+    if (method === 'POST' && path === '/admin/announce-game') {
+      requireAdmin(authUser)
+      const body = await req.json()
+      const { prize, game_type, theme, extra_message } = body as {
+        prize: string
+        game_type: string
+        theme: string
+        extra_message?: string
+      }
+      if (!prize || !game_type) {
+        return errorResponse('prize and game_type are required', 400)
+      }
+
+      const { data: players, error: playersErr } = await supabase
+        .from('users')
+        .select('email, first_name, name, username')
+        .eq('email_verified', true)
+        .eq('role', 'user')
+
+      if (playersErr) throw playersErr
+      if (!players || players.length === 0) {
+        return jsonResponse({ success: true, sent: 0, failed: 0, message: 'No players to notify.' })
+      }
+
+      let sent = 0
+      let failed = 0
+      for (const player of players) {
+        const displayName = player.first_name ?? player.name ?? player.username ?? null
+        const tpl = gameAnnouncementEmail({ name: displayName, prize, gameType: game_type, theme, extraMessage: extra_message })
+        const result = await sendEmail({ to: player.email, subject: tpl.subject, html: tpl.html })
+        if (result.sent) sent++
+        else failed++
+      }
+
+      return jsonResponse({ success: true, sent, failed })
     }
 
     // ── POST /admin/void-cell ─────────────────────────────────────────────────


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #6 — When a new game starts, admin can now email all verified players with full game details.

- New `gameAnnouncementEmail()` template (prize, game type, theme, optional extra message, plus a fixed button overview section)
- New `POST /admin/announce-game` edge function endpoint
- New "Announce New Game to All Players" card in the Admin Panel (green, placed below Weekly Reset)
- Button overview is automatically included in every announcement email:
  - Pick Three
  - Bomb Button (Hidden Square)
  - I Dare Ya (Centre Square)
  - Watch Your Wallet (Hidden Square — adds or takes away dollars)

## Test plan

- [ ] Log in to Admin Panel → Game Configuration tab
- [ ] Find the "Announce New Game to All Players" card
- [ ] Fill in Prize (required), Game Type (required), Theme (optional), Additional Message (optional)
- [ ] Click Send — confirm toast shows sent/failed counts
- [ ] Check a player's inbox — email should show prize, game type, theme, and the button overview table at the bottom

https://claude.ai/code/session_015KTntMQ3q9jGuxjTwjZFKg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015KTntMQ3q9jGuxjTwjZFKg)_